### PR TITLE
fix SyntaxError: Unexpected token I in JSON at position 0

### DIFF
--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -43,7 +43,7 @@ exports.login = async (req, res, next) => {
       });
     } else {
       res.statusCode = 400;
-      res.send('Invalide Email/Password');
+      res.send({ message: 'Invalide Email/Password' });
     }
   } catch (error) {
     next(error);


### PR DESCRIPTION
This error was cause by the server returning a string value instead on a JSON value as required on the client side.